### PR TITLE
fixed bug in migration with player inventories

### DIFF
--- a/plugins/gridinv/plugins/1_1compat/sv_migrations.lua
+++ b/plugins/gridinv/plugins/1_1compat/sv_migrations.lua
@@ -107,8 +107,22 @@ function PLUGIN:migrateBagSize(res)
 		end)
 end
 
+function PLUGIN:migrateInventorySize(res)
+	local w, h = nut.config.get("invW"), nut.config.get("invH")
+	if (isnumber(w) and isnumber(h)) then
+		local addW = self:addInventoryData(res, "w", w)
+		local addH = self:addInventoryData(res, "h", h)
+		return deferred.all({addW, addH}):next(function()
+			self:print(
+				"\tMigrated player inventory "..res._invID.." with"..
+				" (w,h) = ("..tostring(w)..","..tostring(h)..")"
+			)
+		end)
+	end
+end
+
 function PLUGIN:migrateSize(res)
-	return self:migrateStorageSize(res) or self:migrateBagSize(res)
+	return (res._charID ~= 0 and self:migrateInventorySize(res)) or self:migrateStorageSize(res) or self:migrateBagSize(res)
 end
 
 function PLUGIN:migrateInvType(res)


### PR DESCRIPTION
in 1.1, all player inventories invType field in the database are set to NULL, and the migration script attempts to find inventory sizes from storage containers since in 1.1b with the gridinv storages, their inventory types are all grid: the same as players.